### PR TITLE
Fix news feed migration

### DIFF
--- a/news-bundle/src/Migration/FeedMigration.php
+++ b/news-bundle/src/Migration/FeedMigration.php
@@ -35,7 +35,7 @@ class FeedMigration extends AbstractMigration
     public function run(): MigrationResult
     {
         $schemaManager = $this->connection->createSchemaManager();
-        $columns = array_values($schemaManager->listTableColumns('tl_page'));
+        $columns = array_keys($schemaManager->listTableColumns('tl_page'));
 
         $newFields = [
             'newsArchives' => 'blob NULL',
@@ -47,7 +47,7 @@ class FeedMigration extends AbstractMigration
         ];
 
         foreach ($newFields as $field => $definition) {
-            if (\array_key_exists($field, $columns)) {
+            if (\in_array(strtolower($field), $columns)) {
                 continue;
             }
 


### PR DESCRIPTION
This fixes the news feed migration - otherwise it will currently fail, if the field `tl_page.newsArchives` for example already exists.

You probably meant to either:

* Not use `array_values` in line 38
* and then use `array_key_exists` in line 50

or

* Use `array_keys` in line 38
* and then use `in_array` in line 50

(which this PR is doing now)